### PR TITLE
Updated requirements.txt to fix critical dpendabot security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ idna==2.10
 imagesize==1.2.0
 iniconfig==1.1.1
 Jinja2==2.11.3
-joblib==1.0.1
+joblib>=1.2.0
 Keras-Preprocessing==1.1.2
 Markdown==3.3.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
with package `joblib`.

Ref: https://github.com/alphagov/govuk-content-similarity/security/dependabot/154